### PR TITLE
Fix RPC_SHOWTEXTDRAW

### DIFF
--- a/samp/events.lua
+++ b/samp/events.lua
@@ -158,7 +158,8 @@ INCOMING_RPCS[RPC.SHOWTEXTDRAW]               = {'onShowTextDraw',
     {modelId = 'uint16'},
     {rotation = 'vector3d'},
     {zoom = 'float'},
-    {color = 'int32'},
+    {color1 = 'int16'},
+    {color2 = 'int16'},
     {text = 'string16'}
   }}
 }


### PR DESCRIPTION
Fixes the RPC_SHOWTEXTDRAW. These fields are set on the server side using the [TextDrawSetPreviewVehCol](https://sampwiki.blast.hk/wiki/) function.